### PR TITLE
FIX: Adds case for 1bip fee tier

### DIFF
--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -48,6 +48,9 @@ export function feeTierToTickSpacing(feeTier: BigInt): BigInt {
   if (feeTier.equals(BigInt.fromI32(500))) {
     return BigInt.fromI32(10)
   }
+  if (feeTier.equals(BigInt.fromI32(100))) {
+    return BigInt.fromI32(1)
+  }
 
   throw Error('Unexpected fee tier')
 }


### PR DESCRIPTION
It seems like the new 1bip fee tier broke the subgraphs. I'm unsure which branch was the one previously working, so made a pr against main as well https://github.com/Uniswap/v3-subgraph/pull/71. This pr is currently syncing at https://thegraph.com/hosted-service/subgraph/mariorz/uniswap-v3-minimal