### PR TITLE
FIX: Adds case for 1bip fee tier

### DIFF
--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -50,6 +50,9 @@ export function feeTierToTickSpacing(feeTier: BigInt): BigInt {
   if (feeTier.equals(BigInt.fromI32(500))) {
     return BigInt.fromI32(10)
   }
+  if (feeTier.equals(BigInt.fromI32(100))) {
+    return BigInt.fromI32(1)
+  }
 
   throw Error('Unexpected fee tier')
 }


### PR DESCRIPTION
It seems like the new 1bip fee tier broke the subgraphs. A fork with this pr is currently syncing at https://thegraph.com/hosted-service/subgraph/mariorz/uniswapv3?version=pending