### PR TITLE
Make tsconfig.json extends field not location specific

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@graphprotocol/graph-ts/tsconfig.json",
+  "extends": "@graphprotocol/graph-ts/tsconfig",
   "compilerOptions": {
     "types": ["@graphprotocol/graph-ts"]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@graphprotocol/graph-ts/tsconfig.json",
+  "extends": "@graphprotocol/graph-ts/tsconfig.json",
   "compilerOptions": {
     "types": ["@graphprotocol/graph-ts"]
   }


### PR DESCRIPTION
This changes the the `extends` field in the `tsconfig.json` to work regardless of where the node_modules directory is.

This problem comes up when a package is installed by a hoisting package manager like yarn. When developing a project, the node_modules directory is always going to be local to the project root, but when installing the package in another project, the node_modules directory might be above the project root.
