### PR TITLE
Fix close value same as open

### DIFF
--- a/src/utils/intervalUpdates.ts
+++ b/src/utils/intervalUpdates.ts
@@ -81,6 +81,7 @@ export function updatePoolDayData(event: ethereum.Event): PoolDayData {
   poolDayData.feeGrowthGlobal1X128 = pool.feeGrowthGlobal1X128
   poolDayData.token0Price = pool.token0Price
   poolDayData.token1Price = pool.token1Price
+  poolDayData.close = pool.token0Price
   poolDayData.tick = pool.tick
   poolDayData.tvlUSD = pool.totalValueLockedUSD
   poolDayData.txCount = poolDayData.txCount.plus(ONE_BI)


### PR DESCRIPTION
Using the following query, you can see that open and close is always the same. This PR intends to fix this by assigning current price to the `close` value.

```graphql
{
pool(id: "0x80a9ae39310abf666a87c743d6ebbd0e8c42158e") {
      poolDayData(
        first: 1000
        orderDirection: desc
        orderBy:date
      ) {
        date
        open
        high
        low
        close
      }
    }
  }
```