### PR TITLE
fix: Update poolHourData in handleSwap

### DIFF
--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -451,6 +451,7 @@ export function handleSwap(event: SwapEvent): void {
   token1DayData.save()
   uniswapDayData.save()
   poolDayData.save()
+  poolHourData.save()
   factory.save()
   pool.save()
   token0.save()


### PR DESCRIPTION
Potential fix for #79 
Looks like `poolHourData` was assigned values in the `handleSwap` function but was never saved, hence `volumeUSD` was always 0 for `poolHourData` query. We found this issue in arbitrum-minimal, but looks like it's present for all networks.

