### PR TITLE
Whitelist StakeWise sETH2

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -29,7 +29,8 @@ export let WHITELIST_TOKENS: string[] = [
   '0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8', // yCurv
   '0x956f47f50a910163d8bf957cf5846d573e7f87ca', // FEI
   '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0', // MATIC
-  '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' // AAVE
+  '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9', // AAVE
+  '0xfe2e637202056d30016725477c5da089ab0a043a' // sETH2
 ]
 
 let STABLE_COINS: string[] = [

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -4,8 +4,8 @@ repository: https://github.com/Uniswap/uniswap-v3-subgraph
 schema:
   file: ./schema.graphql
 graft:
-  base: QmS13421u6qsbVdBCrZhdRaZw2wH67drwF3urmueJvvJ5P
-  block: 13591197
+  base: QmZeCuoZeadgHkGwLwMeguyqUKz1WPWQYKcKyMCeQqGhsF
+  block: 12673736
 dataSources:
   - kind: ethereum/contract
     name: Factory


### PR DESCRIPTION
# Intoduction

[StakeWise](https://stakewise.io) is a liquid Ethereum 2.0 staking protocol that tokenizes users' deposits as `sETH2` (principal) tokens and staking rewards as `rETH2` (reward) tokens. Both tokens are mapped 1:1 to ETH. StakeWise has the following main pools on Uniswap:

- [ETH - sETH2 pool](https://info.uniswap.org/#/pools/0x7379e81228514a1d2a6cf7559203998e20598346) has $79.02m of liquidity and allows users to withdraw staked ETH. The withdrawals from the ETH2 chain will be enabled in the future phases.
- [rETH2 - sETH2 pool](https://info.uniswap.org/#/pools/0xa9ffb27d36901f87f1d0f20773f7072e38c5bfba) has $2.78m of liquidity and allows users to compound staking rewards by swapping the reward token (rETH2) into the principal token (sETH2).
- [SWISE - sETH2 pool](https://info.uniswap.org/#/pools/0x992f534fcc87864875224d142d6bf054b1882160) has $1.36m of liquidity and is the main pool for StakeWise governance token (SWISE).

# Problem

All three pools specified above are mapped with [sETH2 token](https://etherscan.io/token/0xFe2e637202056d30016725477c5da089Ab0A043A). As rETH2 - sETH2 and SWISE - sETH2 pools are not mapped with any of the whitelisted tokens, it causes the following issues:

- The volume is always $0.00 on the Uniswap Analytics page
- Coingecko, Coinmarketcap, and other coin metrics websites are not able to detect these pools.
- The TVL is only half of the actual value locked on the Uniswap Analytics page
- Some other issues on the Uniswap Analytics page like an empty graph

As we plan to create more pools paired with the sETH2 token and our main pool for the governance token (SWISE) is paired with sETH2, we would very appreciate the team taking a look into this PR.