### PR TITLE
Save pool in `handleInitialize`

### DIFF
--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -23,9 +23,12 @@ import {
 import { createTick, feeTierToTickSpacing } from '../utils/tick'
 
 export function handleInitialize(event: Initialize): void {
+  // update pool sqrt price and tick
   let pool = Pool.load(event.address.toHexString())
   pool.sqrtPrice = event.params.sqrtPriceX96
   pool.tick = BigInt.fromI32(event.params.tick)
+  pool.save()
+  
   // update token prices
   let token0 = Token.load(pool.token0)
   let token1 = Token.load(pool.token1)


### PR DESCRIPTION
This PR ensures that the updated `Pool` information gets saved when handling `Initialize` events.

Currently, when querying a pool in the subgraph, the `ticks` is `null` right after pool initialization. For example the following query:

```graphql
{
  pool(
    block: { number: 12506298 }
    id: "0xa46466ad5507be77ff5abdc27df9dfeda9bd7aee"
  ) {
    tick
    sqrtPrice
  }
}
```

Produces:
```json
{
  "data": {
    "pool": {
      "sqrtPrice": "0",
      "tick": null
    }
  }
}
```

Note that we are querying the pool on block 12506298 which is [the block on which it was minted](https://etherscan.io/tx/0xdf8ac88c61315d6394590da1f4db654bed61eb3ccbd95dfd4574ea0097786e21). This is also despite the fact that there is an `Initialize { sqrtPriceX96: 21258304117400483398804191781, 
tick: -26313 }` event in that transaction.

<details><summary>The `tick` field won't get populated until some later block after another interaction with the pool.</summary>

```graphql
{
  p0: pool(
    block: { number: 12561653 }
    id: "0xa46466ad5507be77ff5abdc27df9dfeda9bd7aee"
  ) {
    tick
    sqrtPrice
  }
  p1: pool(
    block: { number: 12561654 }
    id: "0xa46466ad5507be77ff5abdc27df9dfeda9bd7aee"
  ) {
    tick
    sqrtPrice
  }
}
```

```json
{
  "data": {
    "p0": {
      "sqrtPrice": "0",
      "tick": null
    },
    "p1": {
      "sqrtPrice": "21034280482056333023520409236",
      "tick": "-26525"
    }
  }
}
```

</details>