### PR TITLE
Fix poolDayData close price

### DIFF
--- a/src/utils/intervalUpdates.ts
+++ b/src/utils/intervalUpdates.ts
@@ -84,6 +84,7 @@ export function updatePoolDayData(event: ethereum.Event): PoolDayData {
   poolDayData.tick = pool.tick
   poolDayData.tvlUSD = pool.totalValueLockedUSD
   poolDayData.txCount = poolDayData.txCount.plus(ONE_BI)
+  poolDayData.close = pool.token0Price
   poolDayData.save()
 
   return poolDayData as PoolDayData


### PR DESCRIPTION
There is an old issue that highlights that the close price of poolDayData is the same as open price. It is because the close price is never updated after given poolDayData was created. 

This PR will add an update in `src/utils/intervalUpdates.ts`. 