### PR TITLE
ci: GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,17 +10,17 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['12.x', '14.x']
+        node: [14, 16]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -28,13 +28,13 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ matrix.os }}-yarn-
+            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
Hello,

Quick follow-up of #41, bumping the default NodeJS versions to run against; and bump major versions of GitHub Actions.

You can see an actual run of this workflows for [NodeJS 14](https://github.com/robiiinos/v3-subgraph/runs/6625761690?check_suite_focus=true) and [NodeJS 16](https://github.com/robiiinos/v3-subgraph/runs/6625761764?check_suite_focus=true)