### PR TITLE
Parsing totalSupply Bigint value from string instead of from i32

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -45,7 +45,7 @@ type Token @entity {
   # token decimals
   decimals: BigInt!
   # token total supply
-  totalSupply: BigInt!
+  totalSupply: BigInt
   # volume in token units
   volume: BigDecimal!
   # volume in derived USD

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -67,9 +67,9 @@ export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
   let totalSupplyValue = null
   let totalSupplyResult = contract.try_totalSupply()
   if (!totalSupplyResult.reverted) {
-    totalSupplyValue = totalSupplyResult as i32
+    return null
   }
-  return BigInt.fromI32(totalSupplyValue as i32)
+  return BigInt.fromString(totalSupplyValue)
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {


### PR DESCRIPTION
Creating big int value from actual uint256 type in smart contact instead of truncating the value from an i32 and making the field optional in the schema