### PR TITLE
BSC - Decimal Fix & Graph-ts Upgade

### DIFF
--- a/abis/ERC20.json
+++ b/abis/ERC20.json
@@ -84,7 +84,7 @@
     "outputs": [
       {
         "name": "",
-        "type": "uint8"
+        "type": "uint32"
       }
     ],
     "payable": false,

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "watch-local": "graph deploy ianlapham/uniswap-v3-bsc --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.20.0",
-    "@graphprotocol/graph-ts": "^0.20.0",
+    "@graphprotocol/graph-cli": "^0.64.1",
+    "@graphprotocol/graph-ts": "^0.32.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.2",

--- a/src/mappings/position-manager.ts
+++ b/src/mappings/position-manager.ts
@@ -100,18 +100,20 @@ export function handleIncreaseLiquidity(event: IncreaseLiquidity): void {
   let token0 = Token.load(position.token0)
   let token1 = Token.load(position.token1)
 
-  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
-  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
+  if (token0 && token1) {
+    let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+    let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
 
-  position.liquidity = position.liquidity.plus(event.params.liquidity)
-  position.depositedToken0 = position.depositedToken0.plus(amount0)
-  position.depositedToken1 = position.depositedToken1.plus(amount1)
+    position.liquidity = position.liquidity.plus(event.params.liquidity)
+    position.depositedToken0 = position.depositedToken0.plus(amount0)
+    position.depositedToken1 = position.depositedToken1.plus(amount1)
+  }
 
-  updateFeeVars(position!, event, event.params.tokenId)
+  updateFeeVars(position, event, event.params.tokenId)
 
   position.save()
 
-  savePositionSnapshot(position!, event)
+  savePositionSnapshot(position, event)
 }
 
 export function handleDecreaseLiquidity(event: DecreaseLiquidity): void {
@@ -134,16 +136,19 @@ export function handleDecreaseLiquidity(event: DecreaseLiquidity): void {
 
   let token0 = Token.load(position.token0)
   let token1 = Token.load(position.token1)
-  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
-  let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
 
-  position.liquidity = position.liquidity.minus(event.params.liquidity)
-  position.withdrawnToken0 = position.withdrawnToken0.plus(amount0)
-  position.withdrawnToken1 = position.withdrawnToken1.plus(amount1)
+  if (token0 && token1) {
+    let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+    let amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
 
-  position = updateFeeVars(position!, event, event.params.tokenId)
+    position.liquidity = position.liquidity.minus(event.params.liquidity)
+    position.withdrawnToken0 = position.withdrawnToken0.plus(amount0)
+    position.withdrawnToken1 = position.withdrawnToken1.plus(amount1)
+  }
+
+  position = updateFeeVars(position, event, event.params.tokenId)
   position.save()
-  savePositionSnapshot(position!, event)
+  savePositionSnapshot(position, event)
 }
 
 export function handleCollect(event: Collect): void {
@@ -157,9 +162,14 @@ export function handleCollect(event: Collect): void {
   }
 
   let token0 = Token.load(position.token0)
-  let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
-  position.collectedFeesToken0 = position.collectedFeesToken0.plus(amount0)
-  position.collectedFeesToken1 = position.collectedFeesToken1.plus(amount0)
+  let token1 = Token.load(position.token1)
+
+  if (token0 && token1) {
+    let amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+    let amount1 = convertTokenToDecimal(event.params.amount0, token1.decimals)
+    position.collectedFeesToken0 = position.collectedFeesToken0.plus(amount0)
+    position.collectedFeesToken1 = position.collectedFeesToken1.plus(amount1)
+  }
 
   position = updateFeeVars(position!, event, event.params.tokenId)
   position.save()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -87,7 +87,7 @@ export function loadTransaction(event: ethereum.Event): Transaction {
   }
   transaction.blockNumber = event.block.number
   transaction.timestamp = event.block.timestamp
-  transaction.gasUsed = event.transaction.gasUsed
+  transaction.gasUsed = BigInt.zero() //needs to be moved to transaction receipt
   transaction.gasPrice = event.transaction.gasPrice
   transaction.save()
   return transaction as Transaction

--- a/src/utils/intervalUpdates.ts
+++ b/src/utils/intervalUpdates.ts
@@ -21,7 +21,7 @@ import { ethereum } from '@graphprotocol/graph-ts'
  * @param event
  */
 export function updateUniswapDayData(event: ethereum.Event): UniswapDayData {
-  let uniswap = Factory.load(FACTORY_ADDRESS)
+  let uniswap = Factory.load(FACTORY_ADDRESS)!
   let timestamp = event.block.timestamp.toI32()
   let dayID = timestamp / 86400 // rounded
   let dayStartTimestamp = dayID * 86400
@@ -48,7 +48,7 @@ export function updatePoolDayData(event: ethereum.Event): PoolDayData {
     .toHexString()
     .concat('-')
     .concat(dayID.toString())
-  let pool = Pool.load(event.address.toHexString())
+  let pool = Pool.load(event.address.toHexString())!
   let poolDayData = PoolDayData.load(dayPoolID)
   if (poolDayData === null) {
     poolDayData = new PoolDayData(dayPoolID)
@@ -97,7 +97,7 @@ export function updatePoolHourData(event: ethereum.Event): PoolHourData {
     .toHexString()
     .concat('-')
     .concat(hourIndex.toString())
-  let pool = Pool.load(event.address.toHexString())
+  let pool = Pool.load(event.address.toHexString())!
   let poolHourData = PoolHourData.load(hourPoolID)
   if (poolHourData === null) {
     poolHourData = new PoolHourData(hourPoolID)
@@ -141,7 +141,7 @@ export function updatePoolHourData(event: ethereum.Event): PoolHourData {
 }
 
 export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDayData {
-  let bundle = Bundle.load('1')
+  let bundle = Bundle.load('1')!
   let timestamp = event.block.timestamp.toI32()
   let dayID = timestamp / 86400
   let dayStartTimestamp = dayID * 86400
@@ -184,7 +184,7 @@ export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDa
 }
 
 export function updateTokenHourData(token: Token, event: ethereum.Event): TokenHourData {
-  let bundle = Bundle.load('1')
+  let bundle = Bundle.load('1')!
   let timestamp = event.block.timestamp.toI32()
   let hourIndex = timestamp / 3600 // get unique hour within unix history
   let hourStartUnix = hourIndex * 3600 // want the rounded effect

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -5,7 +5,7 @@ import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 import { exponentToBigDecimal, safeDiv } from '../utils/index'
 
 const WBNB_ADDRESS = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'
-const USDC_WBNB_03_POOL = '0x0f338ec12d3f7c3d77a4b9fcc1f95f3fb6ad0ea6'
+const USDC_WBNB_03_POOL = '0x6fe9e9de56356f7edbfcbb29fab7cd69471a4869'
 
 // token where amounts should contribute to tracked volume and liquidity
 // usually tokens that many tokens are paired with s

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -5,7 +5,7 @@ import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 import { exponentToBigDecimal, safeDiv } from '../utils/index'
 
 const WBNB_ADDRESS = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'
-const USDC_WBNB_03_POOL = '0x6bcb0Ba386E9de0C29006e46B2f01f047cA1806E'
+const USDC_WBNB_03_POOL = '0x0f338ec12d3f7c3d77a4b9fcc1f95f3fb6ad0ea6'
 
 // token where amounts should contribute to tracked volume and liquidity
 // usually tokens that many tokens are paired with s

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -9,18 +9,16 @@ const USDC_WBNB_03_POOL = '0x6bcb0Ba386E9de0C29006e46B2f01f047cA1806E'
 
 // token where amounts should contribute to tracked volume and liquidity
 // usually tokens that many tokens are paired with s
-export let WHITELIST_TOKENS: string[] = [
-  WBNB_ADDRESS,
-]
+export let WHITELIST_TOKENS: string[] = [WBNB_ADDRESS]
 
 let STABLE_COINS: string[] = [
   '0x55d398326f99059ff775485246999027b3197955', // USDT
-  '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d', // USDC
+  '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d' // USDC
 ]
 
-let MINIMUM_ETH_LOCKED = BigDecimal.fromString('0')
+let MINIMUM_ETH_LOCKED = BigDecimal.fromString('300')
 
-let Q192 = 2 ** 192
+let Q192 = BigInt.fromI32(2).pow(192 as u8)
 export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt, token0: Token, token1: Token): BigDecimal[] {
   let num = sqrtPriceX96.times(sqrtPriceX96).toBigDecimal()
   let denom = BigDecimal.fromString(Q192.toString())
@@ -74,7 +72,7 @@ export function findBnbPerToken(token: Token): BigDecimal {
       if (!pool) {
         return ZERO_BD
       }
-    
+
       if (pool.liquidity.gt(ZERO_BI)) {
         if (pool.token0 == token.id) {
           // whitelist token is token1
@@ -82,7 +80,7 @@ export function findBnbPerToken(token: Token): BigDecimal {
           if (!token1) {
             return ZERO_BD
           }
-        
+
           // get the derived ETH in pool
           let ethLocked = pool.totalValueLockedToken1.times(token1.derivedETH)
           if (ethLocked.gt(largestLiquidityETH) && ethLocked.gt(MINIMUM_ETH_LOCKED)) {
@@ -96,7 +94,7 @@ export function findBnbPerToken(token: Token): BigDecimal {
           if (!token0) {
             return ZERO_BD
           }
-        
+
           // get the derived ETH in pool
           let ethLocked = pool.totalValueLockedToken0.times(token0.derivedETH)
           if (ethLocked.gt(largestLiquidityETH) && ethLocked.gt(MINIMUM_ETH_LOCKED)) {

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -22,7 +22,7 @@ export function fetchTokenSymbol(tokenAddress: Address): string {
       } else {
         // try with the static definition
         let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
-        if(staticTokenDefinition != null) {
+        if (staticTokenDefinition != null) {
           symbolValue = staticTokenDefinition.symbol
         }
       }
@@ -50,7 +50,7 @@ export function fetchTokenName(tokenAddress: Address): string {
       } else {
         // try with the static definition
         let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
-        if(staticTokenDefinition != null) {
+        if (staticTokenDefinition != null) {
           nameValue = staticTokenDefinition.name
         }
       }
@@ -64,28 +64,30 @@ export function fetchTokenName(tokenAddress: Address): string {
 
 export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
   let contract = ERC20.bind(tokenAddress)
-  let totalSupplyValue = null
+  let totalSupplyValue = BigInt.zero()
   let totalSupplyResult = contract.try_totalSupply()
   if (!totalSupplyResult.reverted) {
-    totalSupplyValue = totalSupplyResult as i32
+    totalSupplyValue = totalSupplyResult.value
   }
-  return BigInt.fromI32(totalSupplyValue as i32)
+  return totalSupplyValue
 }
 
-export function fetchTokenDecimals(tokenAddress: Address): BigInt {
+export function fetchTokenDecimals(tokenAddress: Address): BigInt | null {
   let contract = ERC20.bind(tokenAddress)
   // try types uint8 for decimals
-  let decimalValue = null
   let decimalResult = contract.try_decimals()
+
   if (!decimalResult.reverted) {
-    decimalValue = decimalResult.value
+    if (decimalResult.value.lt(BigInt.fromI32(255))) {
+      return decimalResult.value
+    }
   } else {
     // try with the static definition
     let staticTokenDefinition = StaticTokenDefinition.fromAddress(tokenAddress)
-    if(staticTokenDefinition != null) {
+    if (staticTokenDefinition) {
       return staticTokenDefinition.decimals
     }
   }
 
-  return BigInt.fromI32(decimalValue as i32)
+  return null
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -5,7 +5,7 @@ schema:
   file: ./schema.graphql
 graft:
   base: QmSnpjbMEbFU7EJhJKSDsL6T2xNvgMcebWWcX4DpWX5u9e
-  block: 27236113
+  block: 34643120
 features:
   - nonFatalErrors
   - grafting

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,10 +1,14 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 description: Uniswap is a decentralized protocol for automated token exchange on Ethereum.
 repository: https://github.com/Uniswap/uniswap-v3-subgraph
 schema:
   file: ./schema.graphql
+graft:
+  base: QmSnpjbMEbFU7EJhJKSDsL6T2xNvgMcebWWcX4DpWX5u9e
+  block: 35850000
 features:
   - nonFatalErrors
+  - grafting
 dataSources:
   - kind: ethereum/contract
     name: Factory
@@ -15,7 +19,7 @@ dataSources:
       startBlock: 25605652
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mappings/factory.ts
       entities:
@@ -43,7 +47,7 @@ templates:
       abi: Pool
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.4
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mappings/core.ts
       entities:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -5,7 +5,7 @@ schema:
   file: ./schema.graphql
 graft:
   base: QmSnpjbMEbFU7EJhJKSDsL6T2xNvgMcebWWcX4DpWX5u9e
-  block: 35850000
+  block: 27236113
 features:
   - nonFatalErrors
   - grafting


### PR DESCRIPTION
Fixes:

- Updated graph-ts and cli & AS migrations
- Updated ERC20 ABI to allow larger decimals and add a less than 255 check in fetchTokenDecimals()
- Updated MIN_ETH_LOCKED to 300 BNB to fix TVL issues
- Updated reference pool to `0x6fe9e9de56356f7edbfcbb29fab7cd69471a4869` since the currently reference pool only has 6k TVL
- Rewound graft block to handle recent TVL issues