### PR TITLE
feat: use fast exponentiation for better perf

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,7 +20,17 @@ export function safeDiv(amount0: BigDecimal, amount1: BigDecimal): BigDecimal {
   }
 }
 
-export function fastPowImpl(value: BigDecimal, power: i32): BigDecimal {
+/**
+ * Implements exponentiation by squaring
+ * (see https://en.wikipedia.org/wiki/Exponentiation_by_squaring )
+ * to minimize the number of BigDecimal operations and their impact on performance.
+ */
+export function fastPow(value: BigDecimal, power: i32): BigDecimal {
+  if (power < 0) {
+    let result = fastPow(value, -power);
+    return safeDiv(ONE_BD, result);
+  }
+
   if (power == 0) {
     return ONE_BD;
   }
@@ -30,22 +40,16 @@ export function fastPowImpl(value: BigDecimal, power: i32): BigDecimal {
   }
 
   let halfPower = power / 2;
-  let halfResult = fastPowImpl(value, halfPower);
+  let halfResult = fastPow(value, halfPower);
+
+  // Use the fact that x ^ (2n) = (x ^ n) * (x ^ n) and we can compute (x ^ n) only once.
   let result = halfResult.times(halfResult);
+
+  // For odd powers, x ^ (2n + 1) = (x ^ 2n) * x
   if (power % 2 == 1) {
     result = result.times(value);
   }
   return result;
-}
-
-export function fastPow(value: BigDecimal, power: i32): BigDecimal {
-  if (power < 0) {
-    let result = fastPowImpl(value, -power);
-    result = safeDiv(ONE_BD, result);
-    return result;
-  }
-
-  return fastPowImpl(value, power);
 }
 
 export function tokenAmountToDecimal(tokenAmount: BigInt, exchangeDecimals: BigInt): BigDecimal {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,9 +25,9 @@ export function safeDiv(amount0: BigDecimal, amount1: BigDecimal): BigDecimal {
  * (see https://en.wikipedia.org/wiki/Exponentiation_by_squaring )
  * to minimize the number of BigDecimal operations and their impact on performance.
  */
-export function fastPow(value: BigDecimal, power: i32): BigDecimal {
+export function fastExponentiation(value: BigDecimal, power: i32): BigDecimal {
   if (power < 0) {
-    let result = fastPow(value, -power);
+    let result = fastExponentiation(value, -power);
     return safeDiv(ONE_BD, result);
   }
 
@@ -40,7 +40,7 @@ export function fastPow(value: BigDecimal, power: i32): BigDecimal {
   }
 
   let halfPower = power / 2;
-  let halfResult = fastPow(value, halfPower);
+  let halfResult = fastExponentiation(value, halfPower);
 
   // Use the fact that x ^ (2n) = (x ^ n) * (x ^ n) and we can compute (x ^ n) only once.
   let result = halfResult.times(halfResult);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,34 @@ export function bigDecimalExponated(value: BigDecimal, power: BigInt): BigDecima
   return result
 }
 
+export function fastPowImpl(value: BigDecimal, power: i32): BigDecimal {
+  if (power == 0) {
+    return ONE_BD;
+  }
+
+  if (power == 1) {
+    return value;
+  }
+
+  let halfPower = power / 2;
+  let halfResult = fastPowImpl(value, halfPower);
+  let result = halfResult.times(halfResult);
+  if (power % 2 == 1) {
+    result = result.times(value);
+  }
+  return result;
+}
+
+export function fastPow(value: BigDecimal, power: i32): BigDecimal {
+  if (power < 0) {
+    let result = fastPowImpl(value, -power);
+    result = safeDiv(ONE_BD, result);
+    return result;
+  }
+
+  return fastPowImpl(value, power);
+}
+
 export function tokenAmountToDecimal(tokenAmount: BigInt, exchangeDecimals: BigInt): BigDecimal {
   if (exchangeDecimals == ZERO_BI) {
     return tokenAmount.toBigDecimal()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,24 +20,6 @@ export function safeDiv(amount0: BigDecimal, amount1: BigDecimal): BigDecimal {
   }
 }
 
-export function bigDecimalExponated(value: BigDecimal, power: BigInt): BigDecimal {
-  if (power.equals(ZERO_BI)) {
-    return ONE_BD
-  }
-  let negativePower = power.lt(ZERO_BI)
-  let result = ZERO_BD.plus(value)
-  let powerAbs = power.abs()
-  for (let i = ONE_BI; i.lt(powerAbs); i = i.plus(ONE_BI)) {
-    result = result.times(value)
-  }
-
-  if (negativePower) {
-    result = safeDiv(ONE_BD, result)
-  }
-
-  return result
-}
-
 export function fastPowImpl(value: BigDecimal, power: i32): BigDecimal {
   if (power == 0) {
     return ONE_BD;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,14 +1,16 @@
 /* eslint-disable prefer-const */
 import { BigInt, BigDecimal, ethereum } from '@graphprotocol/graph-ts'
 import { Transaction } from '../types/schema'
-import { ONE_BI, ZERO_BI, ZERO_BD, ONE_BD } from '../utils/constants'
+import { ZERO_BI, ZERO_BD, ONE_BD } from '../utils/constants'
 
 export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
-  let bd = BigDecimal.fromString('1')
-  for (let i = ZERO_BI; i.lt(decimals as BigInt); i = i.plus(ONE_BI)) {
-    bd = bd.times(BigDecimal.fromString('10'))
+  let resultString = '1';
+
+  for (let i = 0; i < decimals.toI32(); i++) {
+    resultString += '0';
   }
-  return bd
+
+  return BigDecimal.fromString(resultString);
 }
 
 // return 0 if denominator is 0 in division

--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
 import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
-import { bigDecimalExponated, safeDiv } from '.'
+import { fastPow, safeDiv } from '.'
 import { Tick } from '../types/schema'
 import { Mint as MintEvent } from '../types/templates/Pool/Pool'
 import { ONE_BD, ZERO_BD, ZERO_BI } from './constants'
@@ -21,7 +21,7 @@ export function createTick(tickId: string, tickIdx: i32, poolId: string, event: 
   tick.price1 = ONE_BD
 
   // 1.0001^tick is token1/token0.
-  let price0 = bigDecimalExponated(BigDecimal.fromString('1.0001'), BigInt.fromI32(tickIdx))
+  let price0 = fastPow(BigDecimal.fromString('1.0001'), tickIdx);
   tick.price0 = price0
   tick.price1 = safeDiv(ONE_BD, price0)
 

--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-const */
 import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
-import { fastPow, safeDiv } from '.'
+import { fastExponentiation, safeDiv } from '.'
 import { Tick } from '../types/schema'
 import { Mint as MintEvent } from '../types/templates/Pool/Pool'
 import { ONE_BD, ZERO_BD, ZERO_BI } from './constants'
@@ -21,7 +21,7 @@ export function createTick(tickId: string, tickIdx: i32, poolId: string, event: 
   tick.price1 = ONE_BD
 
   // 1.0001^tick is token1/token0.
-  let price0 = fastPow(BigDecimal.fromString('1.0001'), tickIdx);
+  let price0 = fastExponentiation(BigDecimal.fromString('1.0001'), tickIdx);
   tick.price0 = price0
   tick.price1 = safeDiv(ONE_BD, price0)
 


### PR DESCRIPTION
This PR replaces two functions that cause a lot of slowness due to running a lot of BigDecimal operations with more efficient versions.
- `fastExponentiation` replaces the `bigDecimalExponated` with an implementation of [exponentiation by squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring) in order to get the number of multiplications from O(N) to O(log N) on the power. This is particularly effective for large powers in the hundreds or thousands.
- `exponentToBigDecimal` replaces the 10^N computation with a string-based implementation. This sounds weird at first, but it helps with performance because it replaces N calls to BigDecimal operations with only one at the end.

A possible further optimization to the `fastExponentiation` is to expose that as a WebAssembly host function at the graph-node level. This should help optimize performance further by removing the need to pass BigDecimal values back and forth between the AssemblyScript handler function and the Rust `BigDecimal.times` host function.