### PR TITLE
Fix the graph link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Subgraph Endpoint
 
-Synced at: https://thegraph.com/hosted-service/subgraph/ianlapham/uniswap-v3-subgraph?selected=playground
+Synced at: https://thegraph.com/hosted-service/subgraph/uniswap/uniswap-v3?selected=playground
 
 Pending Changes at same URL
 


### PR DESCRIPTION
Other link was moved? I couldn't query subgraph at: https://thegraph.com/hosted-service/subgraph/ianlapham/uniswap-v3-subgraph?selected=playground