### PR TITLE
remove unused tick spacing function

### DIFF
--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -27,20 +27,3 @@ export function createTick(tickId: string, tickIdx: i32, poolId: string, event: 
 
   return tick
 }
-
-export function feeTierToTickSpacing(feeTier: BigInt): BigInt {
-  if (feeTier.equals(BigInt.fromI32(10000))) {
-    return BigInt.fromI32(200)
-  }
-  if (feeTier.equals(BigInt.fromI32(3000))) {
-    return BigInt.fromI32(60)
-  }
-  if (feeTier.equals(BigInt.fromI32(500))) {
-    return BigInt.fromI32(10)
-  }
-  if (feeTier.equals(BigInt.fromI32(100))) {
-    return BigInt.fromI32(1)
-  }
-
-  throw Error('Unexpected fee tier')
-}


### PR DESCRIPTION
this function is unused and may be misleading, we thought we had to modify this in order to pick up the new fee tiers on base 