### PR TITLE
update base min eth locked

### DIFF
--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -147,7 +147,7 @@ export function getSubgraphConfig(): SubgraphConfig {
       stablecoinWrappedNativePoolAddress: '0x4c36388be6f416a29c8d8eee81c771ce6be14b18', // WETH-USDbC 0.05% pool
       stablecoinIsToken0: false,
       wrappedNativeAddress: '0x4200000000000000000000000000000000000006', // WETH
-      minimumNativeLocked: BigDecimal.fromString('1'),
+      minimumNativeLocked: BigDecimal.fromString('4'),
       stablecoinAddresses: [
         '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // USDC
       ],


### PR DESCRIPTION
There is a pool with roughly 1 ETH locked that has inflated TVL. Increasing the min eth locked required to price a pool will remove this artifact. 

https://uniswapteam.slack.com/archives/C04D07TQBT4/p1729015239066479