### PR TITLE
Add USDT and PBTC to Base whitelist and stable coin config

### DIFF
--- a/config/base/chain.ts
+++ b/config/base/chain.ts
@@ -21,10 +21,13 @@ export const WHITELIST_TOKENS: string[] = [
   REFERENCE_TOKEN, // WETH
   '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e', // USDC
   '0x1111111111166b7fe7bd91427724b487980afc69', // ZORA
+  '0xfde4c96c8593536e31f229ea8f37b2ada2699bb2', // USDT
+  '0x31705474c1f2de7f738e34233c49522ca1e3c53c', // PBTC
 ]
 
 export const STABLE_COINS: string[] = [
   '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e', // USDC
+  '0xfde4c96c8593536e31f229ea8f37b2ada2699bb2', // USDT
 ]
 
 export const SKIP_POOLS: string[] = []


### PR DESCRIPTION
**Summary**
This PR adds PBTC and USDT to the WHITELIST_TOKENS array for Base, and marks USDT as a stablecoin. This is required to ensure proper TVL tracking for PBTC-related pools, which are currently being skipped.

**Context**
PBTC is a token on Base with growing usage across multiple trading pairs (PBTC/USDT, PBTC/WETH, PBTC/COAL). We raised $20,000 in a pre-sale which was used 100% for the PBTC/USDT pool that now already has over $80,000 liquidity after less than one month.

We're preparing to launch a powerful token creator (Token Forge) where all tokens will be paired with PBTC, making accurate TVL tracking and routing essential. Please check our website and social media for more details about the project.

Website: https://www.pepe-bitcoin.com/
X: https://x.com/PepeBitcoinPBTC

**Changes**
- Added PBTC (0x31705474c1f2de7f738e34233c49522ca1e3c53c) to WHITELIST_TOKENS
- Added USDT (0xfde4c96c8593536e31f229ea8f37b2ada2699bb2) to WHITELIST_TOKENS
- Marked USDT as a STABLE_COIN

Please let me know if anything else is needed.