### PR TITLE
Support Lens chain

### DIFF
--- a/config/lens/.subgraph-env
+++ b/config/lens/.subgraph-env
@@ -1,0 +1,2 @@
+V3_TOKEN_SUBGRAPH_NAME="v3-tokens-lens"
+V3_SUBGRAPH_NAME="uniswap-v3-lens"

--- a/config/lens/chain.ts
+++ b/config/lens/chain.ts
@@ -1,0 +1,41 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+
+export const FACTORY_ADDRESS = '0xe0704DB90bcAA1eAFc00E958FF815Ab7aa11Ef47'
+
+export const REFERENCE_TOKEN = '0x6bdc36e20d267ff0dd6097799f82e78907105e2f' // WGHO
+export const STABLE_TOKEN_POOL = '0x5eb6b146d7a5322b763c8f8b0eb2fdd5d15e49de' // WGHO/USDC 0.01%
+
+export const TVL_MULTIPLIER_THRESHOLD = '2'
+export const MATURE_MARKET = '1000000'
+export const MINIMUM_NATIVE_LOCKED = BigDecimal.fromString('1')
+
+export const ROLL_DELETE_HOUR = 768
+export const ROLL_DELETE_MINUTE = 1680
+
+export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
+export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
+
+// token where amounts should contribute to tracked volume and liquidity
+// usually tokens that many tokens are paired with s
+export const WHITELIST_TOKENS: string[] = [
+  '0x6bdc36e20d267ff0dd6097799f82e78907105e2f', // WGHO
+  '0xe5ecd226b3032910ceaa43ba92ee8232f8237553', // WETH
+  '0x88f08e304ec4f90d644cec3fb69b8ad414acf884', // USDC
+]
+
+export const STABLE_COINS: string[] = [
+  '0x88f08e304ec4f90d644cec3fb69b8ad414acf884', // USDC
+]
+
+export const SKIP_POOLS: string[] = []
+
+export const POOL_MAPINGS: Array<Address[]> = []
+
+export class TokenDefinition {
+  address: Address
+  symbol: string
+  name: string
+  decimals: BigInt
+}
+
+export const STATIC_TOKEN_DEFINITIONS: TokenDefinition[] = []

--- a/config/lens/chain.ts
+++ b/config/lens/chain.ts
@@ -1,12 +1,12 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 
-export const FACTORY_ADDRESS = '0xe0704DB90bcAA1eAFc00E958FF815Ab7aa11Ef47'
+export const FACTORY_ADDRESS = Address.fromString('0xe0704DB90bcAA1eAFc00E958FF815Ab7aa11Ef47')
 
 export const REFERENCE_TOKEN = '0x6bdc36e20d267ff0dd6097799f82e78907105e2f' // WGHO
 export const STABLE_TOKEN_POOL = '0x5eb6b146d7a5322b763c8f8b0eb2fdd5d15e49de' // WGHO/USDC 0.01%
 
 export const TVL_MULTIPLIER_THRESHOLD = '2'
-export const MATURE_MARKET = '1000000'
+export const MATURE_MARKET = '10000'
 export const MINIMUM_NATIVE_LOCKED = BigDecimal.fromString('1')
 
 export const ROLL_DELETE_HOUR = 768

--- a/config/lens/config.json
+++ b/config/lens/config.json
@@ -1,5 +1,5 @@
 {
   "network": "lens",
   "factory": "0xe0704DB90bcAA1eAFc00E958FF815Ab7aa11Ef47",
-  "startblock": "184121"
+  "startblock": "184120"
 }

--- a/config/lens/config.json
+++ b/config/lens/config.json
@@ -1,0 +1,5 @@
+{
+  "network": "lens",
+  "factory": "0xe0704DB90bcAA1eAFc00E958FF815Ab7aa11Ef47",
+  "startblock": "184121"
+}

--- a/script/utils/prepareNetwork.ts
+++ b/script/utils/prepareNetwork.ts
@@ -11,6 +11,7 @@ export enum NETWORK {
   BSC = 'bsc',
   CELO = 'celo',
   ETHEREUM = 'ethereum',
+  LENS = 'lens',
   MATIC = 'matic',
   OPTIMISM = 'optimism',
   SONEIUM = 'soneium-mainnet',


### PR DESCRIPTION
This PR adds support for the Lens chain. The tokens/pools data is taken from https://oku.trade/info/lens/pools

The mature market threshold is set to $10k(https://github.com/Uniswap/v3-subgraph/pull/267/files#diff-8debb4e000dcaa1aee6cff5a408abda70ab684e2f55017449e7808f3533c9264R9) since the chain's main pools have very low TVLs: https://oku.trade/info/lens/pools?poolsSortBy=tvl_usd.desc

The deployed example: https://thegraph.com/explorer/subgraphs/4BTywu9Kav6vnHRLpWe3E1RYvgrQYxZvppgthZjWa74q?view=Query&chain=arbitrum-one