### PR TITLE
fix: standardize FACTORY_ADDRESS as string across all chains

### DIFF
--- a/config/bsc/chain.ts
+++ b/config/bsc/chain.ts
@@ -1,6 +1,6 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 
-export const FACTORY_ADDRESS = Address.fromString('0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7')
+export const FACTORY_ADDRESS = '0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7'
 
 export const REFERENCE_TOKEN = '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c' // WBNB
 export const STABLE_TOKEN_POOL = '0x6fe9e9de56356f7edbfcbb29fab7cd69471a4869' // WBNB/USDT 0.05%

--- a/config/celo/chain.ts
+++ b/config/celo/chain.ts
@@ -1,6 +1,6 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 
-export const FACTORY_ADDRESS = Address.fromString('0x1F98431c8aD98523631AE4a59f267346ea31F984')
+export const FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984'
 
 export const REFERENCE_TOKEN = '0x471ece3750da237f93b8e339c536989b8978a438'
 export const STABLE_TOKEN_POOL = '0x079e7a44f42e9cd2442c3b9536244be634e8f888'

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -11,6 +11,4 @@ export const ZERO_BD = BigDecimal.fromString('0')
 export const ONE_BD = BigDecimal.fromString('1')
 export const BI_18 = BigInt.fromI32(18)
 
-export const factoryContract = FactoryContract.bind(
-  Address.fromString(Address.fromString(FACTORY_ADDRESS).toHexString())
-)
+export const factoryContract = FactoryContract.bind(Address.fromString(FACTORY_ADDRESS))


### PR DESCRIPTION
## Summary

The `bsc` and `celo` chain configs declare `FACTORY_ADDRESS` as an `Address` via `Address.fromString(...)`, while all other 17 chain configs declare it as a plain string. The consuming code (`src/common/constants.ts`, `entityGetters.ts`, and every v3 / v3-tokens factory, swap, mint, burn, collect mapping) calls `Address.fromString(FACTORY_ADDRESS)`, which only accepts strings. As a result `graph build` aborts on bsc and celo with:

```
ERROR TS2322: Type '~lib/@graphprotocol/graph-ts/common/numbers/Address' is not assignable to type '~lib/string/String'.

   Address.fromString(Address.fromString(FACTORY_ADDRESS).toHexString())
                                         ~~~~~~~~~~~~~~~
 in src/common/constants.ts(15,41)

ERROR TS2322: Type '~lib/@graphprotocol/graph-ts/common/numbers/Address' is not assignable to type '~lib/string/String'.

   const factoryAddress = Address.fromString(FACTORY_ADDRESS)
                                             ~~~~~~~~~~~~~~~
 in src/v3/mappings/factory.ts(12,45)
```

The existing `Address.fromString(Address.fromString(FACTORY_ADDRESS).toHexString())` in `src/common/constants.ts` looks like an attempt to be type-agnostic, but it only works when `FACTORY_ADDRESS` is already a string — `Address.fromString` itself does not accept `Address` inputs, so the workaround does not actually accommodate the bsc/celo case.

Closes #274.

## Changes

- `config/bsc/chain.ts`: `FACTORY_ADDRESS = Address.fromString('0x…')` → `FACTORY_ADDRESS = '0x…'`
- `config/celo/chain.ts`: same change
- `src/common/constants.ts`: collapse the redundant double `Address.fromString(...).toHexString()` to a single `Address.fromString(FACTORY_ADDRESS)`, now safe because the input type is consistent

Net diff: 3 insertions, 5 deletions, 3 files.

## Verification

For each of `bsc`, `celo`, `ethereum`, `arbitrum-one`, `optimism`, `matic`:

```
yarn build --network <chain> --subgraph-type v3
graph build v3-subgraph.yaml

yarn build --network <chain> --subgraph-type v3-tokens
graph build v3-tokens-subgraph.yaml
```

All twelve builds succeed (`Build completed: build/subgraph.yaml`). Before this change, the bsc and celo builds aborted with the TS2322 errors quoted above.

`yarn lint` is clean.
