### PR TITLE
add arc-mainnet (5042) support

### DIFF
--- a/config/arc-mainnet/.subgraph-env
+++ b/config/arc-mainnet/.subgraph-env
@@ -1,0 +1,2 @@
+V3_TOKEN_SUBGRAPH_NAME="uniswap-v3-tokens-arc-mainnet"
+V3_SUBGRAPH_NAME="uniswap-v3-arc-mainnet"

--- a/config/arc-mainnet/chain.ts
+++ b/config/arc-mainnet/chain.ts
@@ -1,0 +1,46 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+
+// Arc (chainId 5042) is Circle's USDC-native L1: the native gas token is USDC, exposed as an
+// ERC-20 at the system address below (6 decimals). There is NO wrapped native — the "WETH9"
+// slot in the Uniswap deployment (0x8bceaa40…) is the UnsupportedProtocol revert stub — so
+// pools pair directly against native USDC, and USDC is the reference token.
+const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
+const EURC = '0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a'.toLowerCase()
+const USYC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'.toLowerCase()
+
+export const FACTORY_ADDRESS = '0xf0db7b58379503491d857db50ac9ece64c653918'
+
+// Reference token is USDC itself (the dollar). Setting STABLE_TOKEN_POOL = REFERENCE_TOKEN
+// signals getEthPriceInUSD() to use a USD price of 1 (no wrapped-native/stable pool exists).
+export const REFERENCE_TOKEN = USDC
+export const STABLE_TOKEN_POOL = REFERENCE_TOKEN
+
+export const TVL_MULTIPLIER_THRESHOLD = '2'
+export const MATURE_MARKET = '1000000'
+export const MINIMUM_NATIVE_LOCKED = BigDecimal.fromString('2000')
+
+export const ROLL_DELETE_HOUR = 768
+export const ROLL_DELETE_MINUTE = 1680
+
+export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
+export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
+
+// tokens whose amounts contribute to tracked volume and liquidity (common pairing tokens)
+export const WHITELIST_TOKENS: string[] = [USDC, EURC, USYC]
+
+// USD-pegged stablecoins only: EURC is EUR-pegged (~$1.08) and USYC is yield-bearing, so both
+// are whitelisted for pricing but excluded from STABLE_COINS (which are treated as exactly $1).
+export const STABLE_COINS: string[] = [USDC]
+
+export const SKIP_POOLS: string[] = []
+
+export const POOL_MAPINGS: Array<Address[]> = []
+
+export class TokenDefinition {
+  address: Address
+  symbol: string
+  name: string
+  decimals: BigInt
+}
+
+export const STATIC_TOKEN_DEFINITIONS: TokenDefinition[] = []

--- a/config/arc-mainnet/chain.ts
+++ b/config/arc-mainnet/chain.ts
@@ -7,6 +7,7 @@ import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
 const EURC = '0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a'.toLowerCase()
 const USYC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'.toLowerCase()
+const CIRBTC = '0x171A4217b86A807A64eB94757Db6849fb4bDbAA0'.toLowerCase() // cirBTC (BTC-pegged) — whitelist only, not a USD stable
 
 export const FACTORY_ADDRESS = '0xf0db7b58379503491d857db50ac9ece64c653918'
 
@@ -26,7 +27,7 @@ export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
 export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
 
 // tokens whose amounts contribute to tracked volume and liquidity (common pairing tokens)
-export const WHITELIST_TOKENS: string[] = [USDC, EURC, USYC]
+export const WHITELIST_TOKENS: string[] = [USDC, EURC, USYC, CIRBTC]
 
 // USD-pegged stablecoins only: EURC is EUR-pegged (~$1.08) and USYC is yield-bearing, so both
 // are whitelisted for pricing but excluded from STABLE_COINS (which are treated as exactly $1).

--- a/config/arc-mainnet/config.json
+++ b/config/arc-mainnet/config.json
@@ -1,0 +1,5 @@
+{
+  "network": "arc-mainnet",
+  "factory": "0xf0db7b58379503491d857db50ac9ece64c653918",
+  "startblock": "1948019"
+}

--- a/script/utils/prepareNetwork.ts
+++ b/script/utils/prepareNetwork.ts
@@ -5,6 +5,7 @@ import * as process from 'process'
 
 export enum NETWORK {
   ARBITRUM = 'arbitrum-one',
+  ARC = 'arc-mainnet',
   AVALANCHE = 'avalanche',
   BASE = 'base',
   BLAST = 'blast-mainnet',

--- a/src/common/pricing.ts
+++ b/src/common/pricing.ts
@@ -23,6 +23,13 @@ export function sqrtPriceX96ToTokenPrices(sqrtPriceX96: BigInt, token0: Token, t
 export function getEthPriceInUSD(): BigDecimal {
   // fetch eth prices for each stablecoin
   let stablePool = STABLE_TOKEN_POOL
+  // On chains where the reference token is itself a USD stablecoin (e.g. Arc, whose native
+  // gas token is USDC and which has no wrapped-native / reference-stable pool), the reference
+  // token's USD price is 1 by definition. Such chains opt in by setting
+  // STABLE_TOKEN_POOL = REFERENCE_TOKEN in their config.
+  if (stablePool == REFERENCE_TOKEN) {
+    return ONE_BD
+  }
   let usdcPool = Pool.load(Address.fromString(stablePool)) // dai is token0
   if (usdcPool) {
     if (usdcPool.token0 == Address.fromString(REFERENCE_TOKEN)) return usdcPool.token1Price


### PR DESCRIPTION
## What

Adds **Arc mainnet** (chainId **5042**, Circle's USDC-native L1) to the v3 + v3-tokens subgraphs.

## The Arc-specific bit: USDC is the native/reference token

Arc's native gas token is **USDC**, and there is **no wrapped native** — the "WETH9" slot in [`deployments/5042.md`](https://github.com/Uniswap/contracts/blob/main/deployments/5042.md) (`0x8bceaa40…`) is the `UnsupportedProtocol` revert stub. So pools pair directly against native USDC (`0x3600…0000`, 6 dec), and **USDC is the reference token**.

Because the reference token *is* the dollar, `getEthPriceInUSD()` must return **1** — there's no wrapped-native/stable pool to derive it from. A chain opts into this by setting `STABLE_TOKEN_POOL = REFERENCE_TOKEN`:

```ts
let stablePool = STABLE_TOKEN_POOL
if (stablePool == REFERENCE_TOKEN) {
  return ONE_BD          // reference token is itself USD (Arc) ⇒ price = 1
}
```

The guard only fires on that equality, so **every other chain is unaffected** (their `STABLE_TOKEN_POOL` is a real pool address). `findEthPerToken` then prices everything else via USDC pools × `ethPriceUSD(=1)` = correct USD.

## Changes
- `src/common/pricing.ts` — the 3-line sentinel above (shared by v3 + v3-tokens).
- `config/arc-mainnet/` — V3 factory `0xf0db7b58379503491d857db50ac9ece64c653918` @ startBlock **1948019**; `REFERENCE_TOKEN = USDC`, `STABLE_TOKEN_POOL = REFERENCE_TOKEN`, `STABLE_COINS = [USDC]`, `WHITELIST = [USDC, EURC, USYC]`, `MINIMUM_NATIVE_LOCKED = 2000` (mirrors `tempo`, the other ~$1-reference chain).
- `script/utils/prepareNetwork.ts` — register `arc-mainnet` in the NETWORK enum.

`EURC` (EUR-pegged) and `USYC` (yield-bearing) are whitelisted but **kept out of `STABLE_COINS`** (which are treated as exactly $1), mirroring how `tempo` excludes EURC.

## Verification
- `yarn build --network arc-mainnet --subgraph-type v3` and `v3-tokens` both compile (manifest → `network: arc-mainnet`, factory `0xf0db7b58…`, startBlock 1948019).

## Notes
- USDC `0x3600…0000` is a system predeploy; `EURC`/`USYC` addresses are from the Arc docs — if the 5042 mainnet addresses differ they're inert (whitelist-only), so no risk to indexing.
- `STABLE_TOKEN_POOL` correctly resolves to the USDC address via the sentinel — no real pool needed.