### PR TITLE
arc: whitelist WETH

### DIFF
--- a/config/arc-mainnet/chain.ts
+++ b/config/arc-mainnet/chain.ts
@@ -8,6 +8,7 @@ const USDC = '0x3600000000000000000000000000000000000000'.toLowerCase()
 const EURC = '0x89B50855Aa3bE2F677cD6303Cec089B5F319D72a'.toLowerCase()
 const USYC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'.toLowerCase()
 const CIRBTC = '0x171A4217b86A807A64eB94757Db6849fb4bDbAA0'.toLowerCase() // cirBTC (BTC-pegged) — whitelist only, not a USD stable
+const WETH = '0x128cC466B61f542da60c70e3aA11c10e19B84EDB'.toLowerCase() // bridged ETH — whitelist only (not the native/reference; Arc's native is USDC)
 
 export const FACTORY_ADDRESS = '0xf0db7b58379503491d857db50ac9ece64c653918'
 
@@ -27,7 +28,7 @@ export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
 export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
 
 // tokens whose amounts contribute to tracked volume and liquidity (common pairing tokens)
-export const WHITELIST_TOKENS: string[] = [USDC, EURC, USYC, CIRBTC]
+export const WHITELIST_TOKENS: string[] = [USDC, EURC, USYC, CIRBTC, WETH]
 
 // USD-pegged stablecoins only: EURC is EUR-pegged (~$1.08) and USYC is yield-bearing, so both
 // are whitelisted for pricing but excluded from STABLE_COINS (which are treated as exactly $1).


### PR DESCRIPTION
Whitelists the bridged WETH `0x128cC466B61f542da60c70e3aA11c10e19B84EDB` on arc-mainnet (v3 + v3-tokens).

Whitelist-only — Arc's native/reference token stays USDC; WETH is a bridged ETH asset (not a stablecoin, not the reference). Builds on the merged arc support (#300).