### PR TITLE
add robinhood-mainnet (4663) support

### DIFF
--- a/config/robinhood-mainnet/.subgraph-env
+++ b/config/robinhood-mainnet/.subgraph-env
@@ -1,0 +1,2 @@
+V3_TOKEN_SUBGRAPH_NAME="uniswap-v3-tokens-robinhood-mainnet"
+V3_SUBGRAPH_NAME="uniswap-v3-robinhood-mainnet"

--- a/config/robinhood-mainnet/chain.ts
+++ b/config/robinhood-mainnet/chain.ts
@@ -1,0 +1,44 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+
+// Robinhood chain (chainId 4663). Standard ETH-native config: the reference token is WETH, priced
+// via the WETH/USDG pool. USDG ("Global Dollar") is the USD stablecoin (6 decimals).
+// NOTE: STABLE_TOKEN_POOL is a zero-address placeholder until the WETH/USDG v3 pool is created and
+// seeded. Until it's set, getEthPriceInUSD() returns 0 (USD metrics read 0; indexing still works).
+// This is NOT the Arc sentinel (which sets STABLE_TOKEN_POOL = REFERENCE_TOKEN to force a price of 1) —
+// here WETH is a volatile reference, so we must read a real pool.
+const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'.toLowerCase()
+const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'.toLowerCase()
+const WETH_USDG_POOL = '0x0000000000000000000000000000000000000000' // TODO: WETH/USDG v3 pool address once seeded
+
+export const FACTORY_ADDRESS = '0x1f7d7550b1b028f7571e69a784071f0205fd2efa'
+
+export const REFERENCE_TOKEN = WETH
+export const STABLE_TOKEN_POOL = WETH_USDG_POOL
+
+export const TVL_MULTIPLIER_THRESHOLD = '2'
+export const MATURE_MARKET = '1000000'
+export const MINIMUM_NATIVE_LOCKED = BigDecimal.fromString('1')
+
+export const ROLL_DELETE_HOUR = 768
+export const ROLL_DELETE_MINUTE = 1680
+
+export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
+export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
+
+// tokens whose amounts contribute to tracked volume and liquidity (common pairing tokens)
+export const WHITELIST_TOKENS: string[] = [WETH, USDG]
+
+export const STABLE_COINS: string[] = [USDG]
+
+export const SKIP_POOLS: string[] = []
+
+export const POOL_MAPINGS: Array<Address[]> = []
+
+export class TokenDefinition {
+  address: Address
+  symbol: string
+  name: string
+  decimals: BigInt
+}
+
+export const STATIC_TOKEN_DEFINITIONS: TokenDefinition[] = []

--- a/config/robinhood-mainnet/config.json
+++ b/config/robinhood-mainnet/config.json
@@ -1,0 +1,5 @@
+{
+  "network": "robinhood-mainnet",
+  "factory": "0x1f7d7550b1b028f7571e69a784071f0205fd2efa",
+  "startblock": "8930"
+}

--- a/script/utils/prepareNetwork.ts
+++ b/script/utils/prepareNetwork.ts
@@ -17,6 +17,7 @@ export enum NETWORK {
   MEGAETH = 'megaeth-mainnet',
   MONAD = 'monad',
   OPTIMISM = 'optimism',
+  ROBINHOOD = 'robinhood-mainnet',
   SONEIUM = 'soneium-mainnet',
   TEMPO = 'tempo',
   UNICHAIN = 'unichain-mainnet',


### PR DESCRIPTION
Adds **Robinhood chain** (chainId 4663, slug `robinhood-mainnet`) to v3 + v3-tokens.

Standard ETH-native chain — **no pricing override** (unlike arc): `REFERENCE_TOKEN = WETH` (`0x0Bd7D308…`), priced via the WETH/USDG pool. USDG ("Global Dollar", 6 dec) is the stablecoin.

**Changes**
- `config/robinhood-mainnet/` — V3 factory `0x1f7d7550…` @ startBlock **8930**; `STABLE_COINS = [USDG]`, `WHITELIST = [WETH, USDG]`.
- `prepareNetwork.ts` — register `robinhood-mainnet`.

⚠️ `STABLE_TOKEN_POOL` is a **zero-address placeholder** until the WETH/USDG v3 pool is created + seeded (the chain-team liquidity step). Until then USD metrics read $0 — indexing works regardless. (Explicitly *not* the arc sentinel, since WETH is a volatile reference.) Add USDC + other tokens to the whitelist as they deploy.

Addresses confirmed against [4663.md](https://github.com/Uniswap/contracts/blob/main/deployments/4663.md) and the RH explorer.