### PR TITLE
fix(robinhood): set WETH/USDG reference pool for USD pricing

### DIFF
--- a/config/robinhood-mainnet/chain.ts
+++ b/config/robinhood-mainnet/chain.ts
@@ -2,13 +2,12 @@ import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 
 // Robinhood chain (chainId 4663). Standard ETH-native config: the reference token is WETH, priced
 // via the WETH/USDG pool. USDG ("Global Dollar") is the USD stablecoin (6 decimals).
-// NOTE: STABLE_TOKEN_POOL is a zero-address placeholder until the WETH/USDG v3 pool is created and
-// seeded. Until it's set, getEthPriceInUSD() returns 0 (USD metrics read 0; indexing still works).
+// STABLE_TOKEN_POOL is the WETH/USDG pool used to derive the ETH price in USD.
 // This is NOT the Arc sentinel (which sets STABLE_TOKEN_POOL = REFERENCE_TOKEN to force a price of 1) —
 // here WETH is a volatile reference, so we must read a real pool.
 const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'.toLowerCase()
 const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'.toLowerCase()
-const WETH_USDG_POOL = '0x0000000000000000000000000000000000000000' // TODO: WETH/USDG v3 pool address once seeded
+const WETH_USDG_POOL = '0x69bfaf19c9f377bb306a89aed9f6b07e2c1a8d9a' // WETH/USDG v3 pool (0.05%)
 
 export const FACTORY_ADDRESS = '0x1f7d7550b1b028f7571e69a784071f0205fd2efa'
 


### PR DESCRIPTION
Sets the WETH/USDG reference pool for Robinhood so the subgraph can derive ETH→USD pricing (was a zero/empty placeholder → ethPriceUSD=0 → all pools reported $0 TVL/volume).

Reference pools (verified live, ~2 ETH liquidity each):
- v2 pair: 0x8803c117ccae7b5146297876c2a25df135141c4d
- v3 pool: 0x69bfaf19c9f377bb306a89aed9f6b07e2c1a8d9a
- v4 pool: 0x387bf619da4d3fb62bb276482693dba1b9b3520f573cabdfe033384a24125982

2.0.0 versions already deployed to Goldsky and verified (ethPriceUSD ~$1340, USD TVL/volume populating); this PR lands the config so future redeploys don't regress to the placeholder.